### PR TITLE
Enable optional HTTP/SSE mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN python -c "from sentence_transformers import SentenceTransformer; \
 EXPOSE 8000
 
 # Run the server
-ENTRYPOINT ["mcp-server-hubspot"] 
+ENTRYPOINT ["mcp-server-hubspot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,8 @@ RUN python -c "from sentence_transformers import SentenceTransformer; \
     model = SentenceTransformer('all-MiniLM-L6-v2'); \
     model.save('/app/models/all-MiniLM-L6-v2')"
 
+# Expose default HTTP port for optional HTTP mode
+EXPOSE 8000
+
 # Run the server
 ENTRYPOINT ["mcp-server-hubspot"] 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ npx -y @smithery/cli@latest install mcp-hubspot --client claude
 docker run -e HUBSPOT_ACCESS_TOKEN=your_token buryhuang/mcp-hubspot:latest
 ```
 
+### HTTP/SSE Mode
+
+Set `MCP_SERVER_HTTP=1` to expose a small FastAPI server with a heartbeat
+SSE stream and a `/tools` endpoint. This is useful for workflows that expect
+HTTP access (e.g. n8n).
+
+```bash
+docker run -e HUBSPOT_ACCESS_TOKEN=your_token \
+           -e MCP_SERVER_HTTP=1 -p 8000:8000 \
+           buryhuang/mcp-hubspot:latest
+```
+
 ### Docker Configuration
 
 For manual configuration in Claude desktop:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ docker run -e HUBSPOT_ACCESS_TOKEN=your_token buryhuang/mcp-hubspot:latest
 ### HTTP/SSE Mode
 
 Set `MCP_SERVER_HTTP=1` to expose a small FastAPI server with a heartbeat
-SSE stream and a `/tools` endpoint. This is useful for workflows that expect
+SSE stream at `/sse` and a `/tools` endpoint. This is useful for workflows that expect
 HTTP access (e.g. n8n).
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,16 @@ version = "0.2.0"
 description = "A simple Hubspot MCP server"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["mcp>=1.4.1", "hubspot-api-client>=11.1.0", "python-dotenv>=1.0.1", "faiss-cpu>=1.7.4", "numpy>=1.24.0", "sentence-transformers>=2.2.2", "huggingface-hub==0.14.1"]
+dependencies = [
+    "mcp>=1.4.1",
+    "hubspot-api-client>=11.1.0",
+    "python-dotenv>=1.0.1",
+    "faiss-cpu>=1.7.4",
+    "numpy>=1.24.0",
+    "sentence-transformers>=2.2.2",
+    "huggingface-hub==0.14.1",
+    "fastapi>=0.110.0"
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ dependencies = [
     "numpy>=1.24.0",
     "sentence-transformers>=2.2.2",
     "huggingface-hub==0.14.1",
-    "fastapi>=0.110.0"
+    "fastapi>=0.110.0",
+    "uvicorn>=0.23.1"
 ]
 
 [build-system]

--- a/src/mcp_server_hubspot/server.py
+++ b/src/mcp_server_hubspot/server.py
@@ -24,7 +24,7 @@ import uvicorn
 # Router for optional HTTP/SSE mode
 router = APIRouter()
 
-@router.get("/stream")
+@router.get("/sse")
 async def stream():
     async def event_generator():
         while True:


### PR DESCRIPTION
## Summary
- expose an SSE `/stream` router
- allow running the server over HTTP when `MCP_SERVER_HTTP=1`
- provide `/tools` endpoint and helper to create FastAPI app
- document the HTTP mode in README
- expose port 8000 in Dockerfile
- add `fastapi` as a project dependency

## Testing
- `python -m py_compile src/mcp_server_hubspot/server.py src/mcp_server_hubspot/__init__.py`

------
https://chatgpt.com/codex/tasks/task_b_687f7aac3de0832489c96290fae5e3cf